### PR TITLE
Add support for deferred msg formating

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ As an example of how to create an assertion, this is `equal`:
 
 ```javascript
 function equal(expected) {
-  return function({ actual, assert, stringify }) {
+  return function({ actual, assert }) {
     return assert(actual === expected,
-      `Expected ${stringify(actual)} to equal ${stringify(expected)}`,
-      `Expected ${stringify(actual)} not to equal ${stringify(expected)}`);
+      [`Expected %j to equal %j`, actual, expected],
+      [`Expected %j not to equal %j`, actual, expected]);
   }
 }
 ```
@@ -99,15 +99,19 @@ And if you want to create an assertion like `beUndefined`, it would only be:
 const beUndefined = ({ actual, assert, stringify }) =>
   assert(actual === undefined,
     `Expected ${stringify(actual)} to be undefined`,
-    `Expected ${stringify(actual)} to not be undefined`);
+    [`Expected %j to not be undefined`, actual]);
 ```
 
 And you can use it like this:
 
-```
+```js
 expect(undefined).to(beUndefined);
 expect('testing').to(not(beUndefined));
 ```
+
+Also, what's up with those error messages?
+
+Using the array syntax is exactly like inlining variables formatted with the `stringify()` function, except that (potentially costly) object serialization is only done when necessary. The `%j` flag is a part of the [`util.format()` api](https://nodejs.org/api/util.html#util_util_format_format), which expect-to is using under the hood, so checkout those docs if you are not familiar.
 
 Why a new assertion library?
 ----------------------------

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,13 @@ module.exports = function(config) {
             exclude: /(node_modules)/,
             loader: 'babel'
           }
-        ]
+        ],
+        noParse: /sinon/
+      },
+      resolve: {
+        alias: {
+          sinon$: 'sinon/pkg/sinon.js'
+        }
       },
       devtool: 'inline-source-map'
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "assertion-error": "^1.0.1",
+    "custom-util-format": "^1.0.0",
     "expect-to-core": "^0.7.0",
     "is-promise": "^2.0.0"
   },
@@ -33,6 +34,7 @@
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.3",
     "pre-commit": "^1.1.2",
+    "sinon": "^1.17.3",
     "standard": "^6.0.8",
     "webpack": "^1.12.14"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,17 @@ import isPromise from 'is-promise'
 import AssertionError from 'assertion-error'
 
 import stringify from './stringify'
+import { formatMsg } from './msg'
 
 function assert (result, msg, err, expected) {
   if (result !== true) {
-    return { msg, expected }
+    return { msg: formatMsg(msg), expected }
   }
 }
 
 assert.not = function assertNot (result, msg, msgNot, expected) {
   if (result !== false) {
-    return { msg: msgNot, expected }
+    return { msg: formatMsg(msgNot), expected }
   }
 }
 
@@ -51,4 +52,3 @@ function throwIfErrorFn (actual) {
 
 export default expect
 export * from 'expect-to-core'
-

--- a/src/index.js
+++ b/src/index.js
@@ -40,16 +40,21 @@ function throwIfErrorFn (actual) {
   return function (res) {
     if (res === undefined) return
 
-    let { expected, msg } = res;
-    if (msg.startsWith('Expected')) {
-      // if the error starts with "Expected" then lower case the error message
-      // to make it compatible with strange mochajs error rendering rule:
+    let { expected, msg } = res
+    const showDiff = expected !== undefined
+
+    if (showDiff) {
+      // if the error starts with "expected" and we can show a diff,
+      // then prefix the error message with `\w+: expected` (lower-case e)
+      // and mocha will drop everything after the :
       // https://github.com/mochajs/mocha/blob/c0f9be244bff479e948f59d1bdb825a45c2cb40c/lib/reporters/base.js#L208-L209
-      msg = 'e' + msg.slice(1)
+
+      if (msg.match(/^expected /i)) {
+        msg = `expect-to assertion failure: expected ${msg.slice(9)}`
+      }
     }
 
-    const showDiff = expected !== undefined
-    throw new AssertionError(`expect-to assertion failure: ${msg}`, { showDiff, actual, expected })
+    throw new AssertionError(msg, { showDiff, actual, expected })
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,13 +40,16 @@ function throwIfErrorFn (actual) {
   return function (res) {
     if (res === undefined) return
 
-    const err = new AssertionError(res.msg, {
-      actual: actual,
-      expected: res.expected,
-      showDiff: res.expected !== undefined
-    })
+    let { expected, msg } = res;
+    if (msg.startsWith('Expected')) {
+      // if the error starts with "Expected" then lower case the error message
+      // to make it compatible with strange mochajs error rendering rule:
+      // https://github.com/mochajs/mocha/blob/c0f9be244bff479e948f59d1bdb825a45c2cb40c/lib/reporters/base.js#L208-L209
+      msg = 'e' + msg.slice(1)
+    }
 
-    throw err
+    const showDiff = expected !== undefined
+    throw new AssertionError(`expect-to assertion failure: ${msg}`, { showDiff, actual, expected })
   }
 }
 

--- a/src/msg.js
+++ b/src/msg.js
@@ -1,37 +1,10 @@
-import { inspect } from 'util';
+import stringify from './stringify'
+import customUtilFormat from 'custom-util-format'
 
-export const inspectOpts = {
-  hidden: false,
-  color: true,
-  depth: 10
-};
-
-export function formatAs(flag, val) {
-  switch (flag) {
-    case 'j':
-      return inspect(val, inspectOpts);
-
-    case 'n':
-      return parseFloat(val);
-
-    case 's':
-    default:
-      return String(val);
-  }
-}
+const format = customUtilFormat({
+  j: stringify
+})
 
 export function formatMsg(msg) {
-  if (!Array.isArray(msg)) return msg;
-
-  const format = msg[0] || '';
-  const args = msg.slice(1);
-
-  return [
-    format.replace(/(.?)%([jsd])/g, (a, pre, flag) => {
-      if (!args.length) return a;
-      if (pre === '%') return `%${flag}`;
-      return (pre || '') + formatAs(flag, args.shift());
-    }),
-    ...args
-  ].join(' ')
+  return Array.isArray(msg) ? format(...msg) : msg
 }

--- a/src/msg.js
+++ b/src/msg.js
@@ -1,0 +1,37 @@
+import { inspect } from 'util';
+
+export const inspectOpts = {
+  hidden: false,
+  color: true,
+  depth: 10
+};
+
+export function formatAs(flag, val) {
+  switch (flag) {
+    case 'j':
+      return inspect(val, inspectOpts);
+
+    case 'n':
+      return parseFloat(val);
+
+    case 's':
+    default:
+      return String(val);
+  }
+}
+
+export function formatMsg(msg) {
+  if (!Array.isArray(msg)) return msg;
+
+  const format = msg[0] || '';
+  const args = msg.slice(1);
+
+  return [
+    format.replace(/(.?)%([jsd])/g, (a, pre, flag) => {
+      if (!args.length) return a;
+      if (pre === '%') return `%${flag}`;
+      return (pre || '') + formatAs(flag, args.shift());
+    }),
+    ...args
+  ].join(' ')
+}

--- a/test.js
+++ b/test.js
@@ -116,35 +116,35 @@ describe('expect-to', () => {
       it('stringifies the arg', () => {
         const arg = { baz: 1 }
         const out = formatMsg(['foo %j bar', arg])
-        expect(out).to(equal(`foo {\n  "baz": 1\n} bar`))
+        test.equal(out, `foo {\n  "baz": 1\n} bar`)
       })
     })
 
     describe('%s placeholder', () => {
       it('stringifies with string constructor', () => {
-        expect(formatMsg(['%s %s', {}])).to(equal('[object Object] %s'))
+        test.equal(formatMsg(['%s %s', {}]), '[object Object] %s')
       })
 
       it('stringifies with string constructor', () => {
-        expect(formatMsg(['-> %s', 'string'])).to(equal('-> string'))
+        test.equal(formatMsg(['-> %s', 'string']), '-> string')
       })
     })
 
     describe('%d placeholder', () => {
       it('formats the arg as a number', () => {
-        expect(formatMsg(['(%d)', {}])).to(equal('(NaN)'))
+        test.equal(formatMsg(['(%d)', {}]), '(NaN)')
       })
 
       it('formats the arg as a number', () => {
-        expect(formatMsg(['** %d', Math.PI])).to(equal('** 3.141592653589793'))
+        test.equal(formatMsg(['** %d', Math.PI]), '** 3.141592653589793')
       })
 
       it('formats the arg as a number', () => {
-        expect(formatMsg(['& %d &', 55])).to(equal('& 55 &'))
+        test.equal(formatMsg(['& %d &', 55]), '& 55 &')
       })
 
       it('formats the arg as a number', () => {
-        expect(formatMsg(['%d', /not a number/])).to(equal('NaN'))
+        test.equal(formatMsg(['%d', /not a number/]), 'NaN')
       })
     })
   })

--- a/test.js
+++ b/test.js
@@ -1,7 +1,13 @@
 /* eslint-env mocha */
 
 import test from 'assert'
+import sinon from 'sinon'
+
+import { formatMsg } from './src/msg'
+import * as msg from './src/msg'
 import expect, { equal, not } from './src'
+
+const stubs = []
 
 describe('expect-to', () => {
   it('triggers callback', () => {
@@ -85,5 +91,61 @@ describe('expect-to', () => {
   it('exports core methods', () => {
     expect('foo').to(equal('foo'))
     expect('foo').to(not(equal('bar')))
+  })
+
+  describe('assert msg', () => {
+    beforeEach(() => stubs.push(sinon.spy(msg, 'formatMsg')))
+    afterEach(() => stubs.splice(0).forEach((s) => s.restore()))
+
+    it('formats assertion messages only when necesarry', function () {
+      expect().to(({ assert }) => assert(true, ['msg %d', 1], 'msgNot', 1))
+      sinon.assert.notCalled(msg.formatMsg)
+
+      try {
+        expect().to(({ assert }) => assert(false, ['msg %d', 2], 'msgNot', 2))
+      } catch (err) {
+        expect(err.message).to(equal('msg 2'))
+      }
+
+      sinon.assert.calledOnce(msg.formatMsg)
+    })
+  })
+
+  describe('msg formatting', () => {
+    describe('%j placeholder', () => {
+      it('stringifies the arg', () => {
+        const arg = { baz: 1 }
+        const out = formatMsg(['foo %j bar', arg])
+        expect(out).to(equal(`foo {\n  "baz": 1\n} bar`))
+      })
+    })
+
+    describe('%s placeholder', () => {
+      it('stringifies with string constructor', () => {
+        expect(formatMsg(['%s %s', {}])).to(equal('[object Object] %s'))
+      })
+
+      it('stringifies with string constructor', () => {
+        expect(formatMsg(['-> %s', 'string'])).to(equal('-> string'))
+      })
+    })
+
+    describe('%d placeholder', () => {
+      it('formats the arg as a number', () => {
+        expect(formatMsg(['(%d)', {}])).to(equal('(NaN)'))
+      })
+
+      it('formats the arg as a number', () => {
+        expect(formatMsg(['** %d', Math.PI])).to(equal('** 3.141592653589793'))
+      })
+
+      it('formats the arg as a number', () => {
+        expect(formatMsg(['& %d &', 55])).to(equal('& 55 &'))
+      })
+
+      it('formats the arg as a number', () => {
+        expect(formatMsg(['%d', /not a number/])).to(equal('NaN'))
+      })
+    })
   })
 })

--- a/test.js
+++ b/test.js
@@ -148,4 +148,60 @@ describe('expect-to', () => {
       })
     })
   })
+
+  describe('mocha compat', () => {
+    function failAssert (errMsg, expected) {
+      expect({ a: 1 }).to(({ assert }) =>
+        assert(false, errMsg, 'not ' + errMsg, expected)
+      )
+    }
+
+    context('error message starts with "expected"', () => {
+      context('assertion has an expected value', () => {
+        it('prefixes error messages', () => {
+          try {
+            failAssert('expected value', 1)
+            test.ok(false, 'Expected assertion to fail')
+          } catch (err) {
+            test.deepEqual(err.message, 'expect-to assertion failure: expected value')
+          }
+        })
+      })
+
+      context('assertion has no expected value', () => {
+        it('does not prefix error messages', () => {
+          try {
+            failAssert('expected nothing')
+            test.ok(false, 'Expected assertion to fail')
+          } catch (err) {
+            test.deepEqual(err.message, 'expected nothing')
+          }
+        })
+      })
+    })
+
+    context('error message starts with "Expected"', () => {
+      context('assertion has an expected value', () => {
+        it('prefixes error messages', () => {
+          try {
+            failAssert('Expected something', 1)
+            test.ok(false, 'Expected assertion to fail')
+          } catch (err) {
+            test.deepEqual(err.message, 'expect-to assertion failure: expected something')
+          }
+        })
+      })
+
+      context('assertion has no expected value', () => {
+        it('does not prefix error messages', () => {
+          try {
+            failAssert('Expected nothing')
+            test.ok(false, 'Expected assertion to fail')
+          } catch (err) {
+            test.deepEqual(err.message, 'Expected nothing')
+          }
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
This adds support for passing a message to `assert()` that will be properly formatted into a message if necessary, but doesn't require possibly costly serialization unless necessary.

Fixes #1 
expect-to-core implementation https://github.com/kjbekkelund/expect-to-core/pull/1

This change also improves the compatibility with mocha's error rendering. Consider [this test](https://gist.github.com/spalger/564443ca4103983aae4a241713f21a55), The error message generated by expect-to includes the entire stringified version of both the actual and expected objects. This information is mostly noise though, especially since mocha supports diff rendering and it still renders the diff below all the noise.

With this change we modify the error message to include a prefix that mocha looks for, and then shortens the error message to just the prefix, which it renders above the diff. It looks like this:

before:
![image](https://cloud.githubusercontent.com/assets/1329312/14951343/246a4d06-100d-11e6-8031-d6ca2488cda5.png)

after: 
![image](https://cloud.githubusercontent.com/assets/1329312/14951471/00e932e2-100e-11e6-857c-3ab39d6b29e7.png)

